### PR TITLE
Add webpack build so it can publish as ES5/JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/dist
 npm-debug.log
 /.idea/

--- a/package.json
+++ b/package.json
@@ -12,5 +12,23 @@
   ],
   "author": "jnieto",
   "license": "",
-  "main": "src/ButtonSpinner.vue"
+  "main": "dist/vue-button-spinner.js",
+  "dependencies": {
+    "vue": "^2.5.2"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --progress --watch",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
+    "prepare": "npm run build"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
+    "cross-env": "^5.1.0",
+    "css-loader": "^0.28.7",
+    "vue-loader": "^13.3.0",
+    "vue-template-compiler": "^2.5.2",
+    "webpack": "^3.8.1"
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,46 @@
+const webpack = require('webpack');
+const path = require('path');
+const PROD = process.env.NODE_ENV === 'production';
+
+module.exports = {
+    entry: path.resolve(__dirname + '/src/VueButtonSpinner.vue'),
+
+    output: {
+        path: path.resolve(__dirname + '/dist/'),
+        filename: 'vue-button-spinner.js',
+
+        libraryTarget: 'umd',
+        library: 'vue-button-spinner',
+        umdNamedDefine: true,
+    },
+
+    module: {
+        loaders: [
+            {
+                test: /\.vue$/,
+                loader: 'vue-loader',
+                options: {
+                    loaders: {
+                        js: {
+                            loader: 'babel-loader',
+                            options: {
+                                presets: ['env'],
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    },
+
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+            minimize: PROD ? true : false,
+            sourceMap: PROD ? false : true,
+            mangle: PROD ? true: false,
+            compress: {
+                warnings: PROD ? false: true
+            },
+        }),
+    ],
+};


### PR DESCRIPTION
Hey there. We used this component recently on a project and noticed that, because of how it was packaged, we couldn't require it via NPM normally because, while it would load, it wasn't being compiled down to ES5 before going through Uglify, and simple ES6 stuff (like line 28 of VueButtonSpinner.vue) was breaking uglify.

This PR adds a simple build, using webpack and vue-loader, so that what's published to NPM is just a plain JS file, ES5, and compatible with things like Uglify.